### PR TITLE
refactor(chatView): Enhance chatView by avoiding webview destruction and boosting operation speed

### DIFF
--- a/src/base/common/defer.ts
+++ b/src/base/common/defer.ts
@@ -1,0 +1,32 @@
+interface Deferred<T> {
+	abort: () => void;
+	resolve: (value: T) => void;
+	reject: (reason?: unknown) => void;
+	promise: Promise<T>;
+}
+
+export function defer<T>(signal?: AbortSignal): Deferred<T> {
+	const ac = new AbortController();
+	const dtd = {} as Deferred<T>;
+
+	dtd.promise = new Promise((resolve, reject) => {
+		dtd.resolve = resolve;
+		dtd.reject = reject;
+	});
+
+	function onDidAbort() {
+		dtd.reject(new Error('user aborted'));
+	}
+
+	ac.signal.addEventListener('abort', onDidAbort);
+
+	if (signal) {
+		signal.addEventListener('abort', onDidAbort);
+	}
+
+	dtd.abort = function () {
+		ac.abort();
+	};
+
+	return dtd;
+}

--- a/src/commands/commandsService.ts
+++ b/src/commands/commandsService.ts
@@ -90,8 +90,6 @@ export class CommandsService {
 			return;
 		}
 
-		// TODO hack message render empty
-		await setTimeout(800);
 
 		const selection = editor.selection;
 		if (selection.isEmpty) {
@@ -124,8 +122,6 @@ export class CommandsService {
 
 		await chat.show();
 
-		// TODO hack message render empty
-		await setTimeout(800);
 		await addHighlightedCodeToContext(editor, selection, chat);
 
 		await setTimeout(800);
@@ -147,8 +143,6 @@ export class CommandsService {
 
 		await chat.show();
 
-		// TODO hack message render empty
-		await setTimeout(600);
 		await addHighlightedCodeToContext(editor, selection, chat);
 
 		await setTimeout(800);

--- a/src/commands/commandsUtils.ts
+++ b/src/commands/commandsUtils.ts
@@ -81,7 +81,7 @@ export async function addHighlightedCodeToContext(editor: TextEditor, selection:
 		},
 	};
 
-	await chat.send('highlightedCode', {
+	await chat.request('highlightedCode', {
 		rangeInFileWithContents,
 	});
 }

--- a/src/editor/views/chat/chatViewService.ts
+++ b/src/editor/views/chat/chatViewService.ts
@@ -29,6 +29,9 @@ export class ChatViewService {
 		return this.continueViewProvider.send(type, message);
 	}
 
+	request(type: string, message?: unknown) {
+		return this.continueViewProvider.request(type, message);
+	}
 	postMessage(message: unknown) {
 		return this.continueViewProvider.postMessage(message);
 	}
@@ -46,6 +49,8 @@ export class ChatViewService {
 	}
 
 	register() {
-		return window.registerWebviewViewProvider(CHAT_VIEW_ID, this.continueViewProvider);
+		return window.registerWebviewViewProvider(CHAT_VIEW_ID, this.continueViewProvider, {
+			webviewOptions: { retainContextWhenHidden: true },
+		});
 	}
 }

--- a/src/editor/views/chat/continue/continueMessages.ts
+++ b/src/editor/views/chat/continue/continueMessages.ts
@@ -209,3 +209,9 @@ export class ContinueEvent<
 		});
 	}
 }
+
+export interface Message<T = any> {
+    messageType: string;
+    messageId: string;
+    data: T;
+}


### PR DESCRIPTION
主要改动：
1. chatView 保持常驻状态，不再自动销毁。
2. 在通信中添加 request 方法，待 GUI 返回后，promise 再进行返回。
3. Quick Chat、explainCode、optimizeCode 采用 request 替代 setTimeout，以提升操作速度。 