### PR TITLE
fix newline bug in completion

### DIFF
--- a/src/action/providers/AutoDevCodeInlineCompletionProvider.ts
+++ b/src/action/providers/AutoDevCodeInlineCompletionProvider.ts
@@ -116,7 +116,8 @@ export class AutoDevCodeInlineCompletionProvider implements vscode.InlineComplet
 			}
 
 			if (result) {
-				return [new vscode.InlineCompletionItem(result.trimStart())];
+				// return [new vscode.InlineCompletionItem(result.trimStart())];
+				return [new vscode.InlineCompletionItem(result)];
 			}
 		} catch (error) {
 			if (!token.isCancellationRequested) {


### PR DESCRIPTION
In original impletion, the newline in start of result string will be trimmed, which is incorrect when when completion contains newline in its start.
![屏幕截图 2024-09-20 164234](https://github.com/user-attachments/assets/2b324073-fceb-473c-9f6a-d12d21849d0a)
